### PR TITLE
resampled fdat file for field data should use simID from simulation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "libvcell"
-version = "0.0.7"
+version = "0.0.8"
 description = "This is a python package which wraps a subset of VCell Java code as a native python package."
 authors = ["Jim Schaff <schaff@uchc.edu>", "Ezequiel Valencia <evalencia@uchc.edu>"]
 repository = "https://github.com/virtualcell/libvcell"

--- a/vcell-native/src/main/java/org/vcell/libvcell/solvers/LocalFVSolverStandalone.java
+++ b/vcell-native/src/main/java/org/vcell/libvcell/solvers/LocalFVSolverStandalone.java
@@ -169,7 +169,7 @@ public class LocalFVSolverStandalone extends FVSolverStandalone {
         for (FieldDataIdentifierSpec fdiSpec: argFieldDataIDSpecs) {
             File ext_dataDir = new File(this.parentDir, fdiSpec.getFieldFuncArgs().getFieldName());
             if (!uniqueFieldDataIDSpecAndFileH.containsKey(fdiSpec)){
-                File newResampledFieldDataFile = new File(dataDir, SimulationData.createCanonicalResampleFileName(fdiSpec.getExternalDataIdentifier(), fdiSpec.getFieldFuncArgs()));
+                File newResampledFieldDataFile = new File(dataDir, SimulationData.createCanonicalResampleFileName(getSimulationJob().getVCDataIdentifier(), fdiSpec.getFieldFuncArgs()));
                 uniqueFieldDataIDSpecAndFileH.put(fdiSpec,newResampledFieldDataFile);
                 bFieldDataResample.put(fdiSpec, bResampleFlags[i]);
             }

--- a/vcell-native/src/test/java/org/vcell/libvcell/EntrypointsTest.java
+++ b/vcell-native/src/test/java/org/vcell/libvcell/EntrypointsTest.java
@@ -68,6 +68,7 @@ public class EntrypointsTest {
         assertEquals(0, countFiles(output_dir));
         String simulationName = "Simulation0";
         vcmlToFiniteVolumeInput(vcmlContent, simulationName, parent_dir, output_dir);
+        listFilesInDirectory(output_dir);
         assertEquals(10, countFiles(ext_data_dir));
         assertEquals(6, countFiles(output_dir));
     }


### PR DESCRIPTION
simID in name of fdat file (resampled field data file) referred to originating dataset rather than target simulation SimID