### PR TITLE
Expose libvcell.__version__ for downstream consumers

### DIFF
--- a/libvcell/__init__.py
+++ b/libvcell/__init__.py
@@ -1,3 +1,5 @@
+from importlib.metadata import PackageNotFoundError, version
+
 from libvcell.model_utils import (
     sbml_to_vcml,
     vcell_infix_to_num_expr_infix,
@@ -7,7 +9,13 @@ from libvcell.model_utils import (
 )
 from libvcell.solver_utils import sbml_to_finite_volume_input, vcml_to_finite_volume_input
 
+try:
+    __version__ = version("libvcell")
+except PackageNotFoundError:  # pragma: no cover - source tree, package not installed
+    __version__ = "0.0.0"
+
 __all__ = [
+    "__version__",
     "vcml_to_finite_volume_input",
     "sbml_to_finite_volume_input",
     "sbml_to_vcml",


### PR DESCRIPTION
## Summary
Adds `libvcell.__version__` so third-party projects (e.g. pyvcell and its upstream users) can read the installed version programmatically.

```python
import libvcell
libvcell.__version__   # e.g. "0.0.16"
```

- Resolved from installed package metadata via `importlib.metadata.version` (single-sourced from `pyproject.toml`, no duplication).
- Falls back to `"0.0.0"` only when running from an uninstalled source tree (`PackageNotFoundError`).

## Typing note
`py.typed` is already present and shipped in the wheels (verified in the published `0.0.15.4` artifact + its RECORD), so libvcell is already fully typed for downstream `mypy --strict` consumers. This PR is the remaining piece of that "make libvcell friendly to typed downstreams" work.

## Verification
- `import libvcell` works without the native lib loaded (lazy-loaded on first call).
- `mypy --strict` passes on the changed module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)