### PR TITLE
Fix MainRecorder invocation in local_build_native.sh

### DIFF
--- a/scripts/local_build_native.sh
+++ b/scripts/local_build_native.sh
@@ -34,6 +34,7 @@ java -agentlib:native-image-agent=config-output-dir=target/recording \
      "$ROOT_DIR/vcell-native/src/test/resources/TinySpatialProject_Application0.xml" \
      "$ROOT_DIR/vcell-native/src/test/resources/TinySpatialProject_Application0.vcml" \
      "Simulation0" \
+     "unnamed_spatialGeom" \
      "$ROOT_DIR/vcell-native/target/sbml-input"
 
 # build vcell-native as native shared object library


### PR DESCRIPTION
## Summary
`scripts/local_build_native.sh` invoked `MainRecorder` with only **4** arguments, but `MainRecorder.main` requires **5** (`sbml_file`, `vcml_file`, `sim_name`, `app_name`, `output_dir`) — with fewer it prints a usage message and returns immediately. As a result, the local build's `native-image-agent` recording step silently captured **nothing**, so a wheel produced by `scripts/local_build_native.sh` could be missing reflection/resource config that the native image needs at runtime.

`build.py` (used by `poetry build`/`poetry install`) already passes the correct 5 args, so this only affected the standalone shell script.

## Fix
Add the missing `app_name` argument (`unnamed_spatialGeom`, matching `build.py`) before the output dir.

Because the recorder runs with its working directory at `vcell-native/`, this also lets the moving-boundary recording block (which reads `src/test/resources/Solver_Suite_6_2.vcml`) execute, so the local build captures config for the `vcmlToMovingBoundaryInput` path too.

## Note
No CI impact (CI uses cibuildwheel/build.py, not this script); this only improves correctness of the documented local macOS native build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)