### PR TITLE
Stop release jobs hanging 6h on failure (gate tmate, add timeouts)

### DIFF
--- a/.github/workflows/on-release-main.yml
+++ b/.github/workflows/on-release-main.yml
@@ -2,6 +2,11 @@ name: release-main
 
 on:
   workflow_dispatch:
+    inputs:
+      debug_tmate:
+        description: "Open an interactive tmate debug session if a job fails"
+        type: boolean
+        default: false
   release:
     types: [published]
     branches: [main]
@@ -22,6 +27,9 @@ jobs:
 
       fail-fast: false
     runs-on: ${{ matrix.os }}
+    # Successful builds take ~35-60 min; cap well under the 6h default so a stuck
+    # job (e.g. a hung publish) fails fast instead of burning a runner for 6 hours.
+    timeout-minutes: 180
     defaults:
       run:
         shell: bash
@@ -109,8 +117,13 @@ jobs:
           poetry publish --skip-existing
         if: github.event_name == 'release'
 
+      # Only open a tmate session when explicitly requested via workflow_dispatch.
+      # On a release event `inputs.debug_tmate` is false, so a failed job fails fast
+      # instead of holding the runner open until the 6h job timeout. The step is also
+      # bounded by timeout-minutes as a safety net.
       - name: Setup tmate
-        if: failure()
+        if: ${{ failure() && inputs.debug_tmate }}
+        timeout-minutes: 30
         uses: mxschmitt/action-tmate@v3
         with:
           limit-access-to-actor: true


### PR DESCRIPTION
## Problem
The `0.0.16` release run finished as **cancelled** after **6h17m**. Root cause: the `Setup tmate` step runs `if: failure()`, opening an interactive debug session that blocks the job until the 6h runner limit. When the PyPI publish step failed (PyPI 10GB project-size limit exceeded), `tmate` then held **7 jobs open for 6 hours each** until the whole run hit the cap and was cancelled.

## Fix
- **Gate the tmate step** behind a `workflow_dispatch` boolean input `debug_tmate` (default `false`). On a `release` event the input is false, so a failed job **fails fast** instead of hanging. The session is still available when you manually run the workflow with the input enabled.
- **Bound the tmate step** with `timeout-minutes: 30`.
- **Job-level `timeout-minutes: 180`** as defense-in-depth (successful builds take ~35–60 min).

## Not addressed here
The underlying publish failure (PyPI 10GB storage limit) is separate — being handled by pruning old releases. This PR just ensures a publish failure surfaces immediately instead of burning 6h × N jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)