### PR TITLE
Ship one py3-none wheel per platform instead of per-Python-version

### DIFF
--- a/.github/workflows/on-release-main.yml
+++ b/.github/workflows/on-release-main.yml
@@ -64,11 +64,10 @@ jobs:
           ARCH=$(uname -m)
           echo "ARCH_DEF=$ARCH" >> $GITHUB_ENV
           echo "MANYLINUX_IMAGE_TARGET=ghcr.io/virtualcell/manylinux_${{ matrix.glibc }}_$ARCH:latest" >> $GITHUB_ENV
-          CIBW_BUILD_STRING="cp310-*${{ env.ARCH_DEF }} cp311-*${{ env.ARCH_DEF }} cp312-*${{ env.ARCH_DEF }} cp313-*${{ env.ARCH_DEF }}"
-          if [ "${{ matrix.glibc }}" = "2_34" ]; then
-            CIBW_BUILD_STRING="$CIBW_BUILD_STRING cp314-*${{ env.ARCH_DEF }}"
-          fi
-          echo "CIBW_BUILD_TARGETS=$CIBW_BUILD_STRING" >> $GITHUB_ENV
+          # libvcell is pure Python + a ctypes-loaded GraalVM native library (no CPython
+          # extension), so the wheel is not tied to a Python version. Build a single
+          # interpreter per platform and retag it to py3-none below.
+          echo "CIBW_BUILD_TARGETS=cp311-*" >> $GITHUB_ENV
 
       - name: Run cibuildwheel (Ubuntu, x86_64)
         uses: pypa/cibuildwheel@v3.4.0
@@ -92,7 +91,21 @@ jobs:
           pip install cibuildwheel
           cibuildwheel --debug-traceback --output-dir wheelhouse
         env:
-          CIBW_BUILD: "cp310-* cp311-* cp312-* cp313-* cp314-*"
+          CIBW_BUILD: "cp311-*"
+
+      - name: Retag wheels as py3-none (ABI-independent, one wheel per platform)
+        run: |
+          python -m pip install --upgrade wheel
+          for whl in wheelhouse/*.whl; do
+            echo "retagging $whl"
+            # Change cp311-cp311 -> py3-none, preserving the (manylinux/macosx/win) platform tag.
+            # The bundled native lib is loaded via ctypes, so it has no CPython ABI dependency
+            # and the resulting wheel installs on any supported Python 3.x. Requires-Python in
+            # the wheel metadata still enforces the >=3.10 floor.
+            python -m wheel tags --python-tag py3 --abi-tag none --remove "$whl"
+          done
+          ls -l wheelhouse
+
       - name: Copy wheels to dist directory
         run: |
           mkdir -p dist


### PR DESCRIPTION
## Why
`libvcell` is **pure Python + a ctypes-loaded GraalVM native library** — there is no compiled CPython extension (`native_utils.py` uses `ctypes.CDLL`; `build.py` has no `Extension`/`ext_modules`). So the wheel has **no CPython ABI dependency** and does not need to be built or tagged per Python version.

> Note: abi3 (`cpNN-abi3`) doesn't apply here — that's for C extensions built against the limited API. `py3-none-<platform>` is the correct, even-more-portable analog: any Python 3.x, no ABI pin. The `>=3.10` floor is still enforced via the wheel's `Requires-Python` metadata.

## What
- Build a **single interpreter (`cp311`)** per platform with cibuildwheel (keeping auditwheel/delocate/delvewheel repair, so `manylinux`/`macosx`/`win` platform tags stay valid).
- **Retag** the result `cp311-cp311-<platform>` → `py3-none-<platform>` (`python -m wheel tags --python-tag py3 --abi-tag none --remove`), preserving the platform tag.

## Effect
| | Before (per-cpNN) | After (py3-none) |
|---|---|---|
| Wheels / release | ~34 | ~7 |
| Size / release | ~1.45 GB | ~0.28 GB |
| Native-image builds | 5 per platform | 1 per platform |

This is the structural fix for the **PyPI 10 GB project-size limit** the per-cp matrix was driving the project toward, and it roughly 5× speeds up the release build.

## Validation
The retag mechanism is the same one used to produce the local macOS arm wheels in this effort (verified: the identical dylib loads on Python 3.12 and 3.14). The release workflow isn't exercised by PR CI, so before relying on it you can **manually run the workflow** (`workflow_dispatch`) — the publish step is gated on `release` events, so a dispatch run builds + dry-run-publishes the py3-none wheels without uploading.

## Follow-up (not in this PR)
The `glibc: [2_28, 2_34]` matrix now yields two redundant Linux wheels per arch — a `manylinux_2_28` wheel already installs on glibc ≥2.28 (incl. 2.34). Dropping the `2_34` dimension is a safe further reduction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)