### PR TITLE
Drop macos-intel (both workflows) + confine release glibc to Linux

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,7 +47,7 @@ jobs:
     strategy:
       matrix: #        python-version: ["3.9", "3.10", "3.11", "3.12"]
         python-version: ["3.11"]
-        os: [macos-15-intel, windows-latest, ubuntu-22.04, macos-15]
+        os: [windows-latest, ubuntu-22.04, macos-15]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     defaults:

--- a/.github/workflows/on-release-main.yml
+++ b/.github/workflows/on-release-main.yml
@@ -17,13 +17,20 @@ jobs:
       matrix:
         os:
           [
-            macos-15-intel,
             windows-latest,
             ubuntu-latest,
             ubuntu-24.04-arm,
             macos-15,
           ]
         glibc: [2_28, 2_34]
+        # glibc (manylinux) only applies to the Linux builds. Exclude the duplicate
+        # 2_34 combination for the non-Linux OSes so macOS/Windows build once each
+        # (otherwise they would build the identical wheel twice, once per glibc value).
+        exclude:
+          - os: windows-latest
+            glibc: 2_34
+          - os: macos-15
+            glibc: 2_34
 
       fail-fast: false
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/on-release-main.yml
+++ b/.github/workflows/on-release-main.yml
@@ -15,13 +15,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os:
-          [
-            windows-latest,
-            ubuntu-latest,
-            ubuntu-24.04-arm,
-            macos-15,
-          ]
+        os: [windows-latest, ubuntu-latest, ubuntu-24.04-arm, macos-15]
         glibc: [2_28, 2_34]
         # glibc (manylinux) only applies to the Linux builds. Exclude the duplicate
         # 2_34 combination for the non-Linux OSes so macOS/Windows build once each


### PR DESCRIPTION
## Changes

**1. Drop `macos-15-intel` from both workflows.** GitHub-hosted macOS Intel runners are scarce and slow to schedule, stalling both releases and PR CI. Apple-silicon macOS coverage is sufficient.
- `on-release-main.yml` build matrix
- `main.yml` `tests-and-type-check` matrix (this is the `tests-and-type-check (3.11, macos-15-intel)` job seen in every PR's checks)

**2. Confine `glibc` to Linux (release workflow).** `glibc` (2_28/2_34) only applies to manylinux builds, but it sat in the top-level matrix and cross-producted onto macOS/Windows, so those jobs ran twice building the identical wheel (the dup just hit `poetry publish --skip-existing`). Added a matrix `exclude` for the `2_34` combo on the non-Linux OSes.

## Effect
- Release build jobs: **10 → 6** (no macOS-Intel; macOS/Windows build once each; Ubuntu x86_64/aarch64 keep both glibc).
- PR/push test jobs: drop the macOS-Intel runner.
- No change to the set of published wheels.

## Note
The release workflow isn't exercised by PR CI; validate via a manual `workflow_dispatch` dry-run if desired. Does not affect the (partial) 0.0.16 already on PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)