### PR TITLE
Bump version to 0.0.17

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "libvcell"
-version = "0.0.16"
+version = "0.0.17"
 description = "This is a python package which wraps a subset of VCell Java code as a native python package."
 authors = ["Jim Schaff <schaff@uchc.edu>", "Ezequiel Valencia <evalencia@uchc.edu>"]
 repository = "https://github.com/virtualcell/libvcell"


### PR DESCRIPTION
Bumps `pyproject.toml` `0.0.16` → `0.0.17` for the next release.

`0.0.17` will be the first release on the cleaned-up workflow:
- One `py3-none-<platform>` wheel per platform (#22) — ~5× fewer/smaller wheels
- No `macos-15-intel` runner; `glibc` confined to Linux (#23)
- No 6h tmate hang on failure (#21)

It supersedes the partial `0.0.16` (Linux + macOS-arm 3.10–3.12 only) that resulted from the PyPI 10 GB size limit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)